### PR TITLE
Fix file removal in buildme.pl.

### DIFF
--- a/buildme.pl
+++ b/buildme.pl
@@ -436,7 +436,7 @@ sub buildTarball {
 			}
 			
 			print "INFO: Removing $dirsToExclude[$n] files from buildDir...\n";
-			system("find $buildDir -depth | grep '$dirsToExclude[$n]' $doInclude | xargs rm -rf &> /dev/null");
+			system("find $buildDir -depth | grep '$dirsToExclude[$n]' $doInclude | xargs rm -rf > /dev/null 2>&1");
 			$n++;
 		}
 			


### PR DESCRIPTION
Change a "&> /dev/null", which only works in bash, to a "> /dev/null 2>&1", which works everywhere. 

Please. :)
