### PR TITLE
Debian: Add icudt58 collation file(s) to installation

### DIFF
--- a/debian/logitechmediaserver.install
+++ b/debian/logitechmediaserver.install
@@ -10,6 +10,7 @@
 ../server/strings.txt  usr/share/squeezeboxserver
 ../server/MySQL        usr/share/squeezeboxserver
 ../server/icudt46*.dat usr/share/squeezeboxserver
+../server/icudt58*.dat usr/share/squeezeboxserver
 ../server/*.conf       etc/squeezeboxserver
 debian/squeezeboxserver_safe  usr/sbin
 ../server/revision.txt usr/share/squeezeboxserver


### PR DESCRIPTION
ICU was updated to version 58.2 in September 2017. We need to include
its collation file in the Debian distribution.

LMS will operate without the file, but throws an exception (below) and
uses “COLLATE perllocale” as a fallback. Refer:

https://github.com/Logitech/slimserver/blob/public/7.9/Slim/Utils/SQLiteHelper.pm#L195

Exception:

[18-02-08 16:09:42.7993] Slim::Schema::Storage::throw_exception (122) Error: DBI Exception: DBD::SQLite::db do failed: SQL logic error or missing database
ICU error: ucol_open(): U_FILE_ACCESS_ERROR [for Statement "SELECT icu_load_collation('en_US', 'en_US')"]
[18-02-08 16:09:42.8036] Slim::Schema::Storage::throw_exception (122) Backtrace: