### PR TITLE
Debian: Add additional package dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Package: logitechmediaserver
 Architecture: all
 Conflicts: slimp3,slimserver,squeezecenter,squeezeboxserver
 Replaces: slimp3,slimserver,squeezecenter,squeezeboxserver
-Depends: perl (>= 5.8.8), adduser, libc6
+Depends: perl (>= 5.8.8), adduser, libc6, libgcc1, libstdc++6, zlib1g, libio-socket-ssl-perl, libgomp1 (>= 4.2.1)
 Description: Streaming Audio Server
  Logitech Media Server is a cross-platform streaming media server that supports a wide range
  of formats, including AAC, AIFF, FLAC, Ogg Vorbis, MP3, WAV, and WMA.


### PR DESCRIPTION
1. Sox

The LMS bundled Sox binary (v14.3.1) has been built with OpenMP support,
and has a dependency on libgomp1. Sox will fail if this library is not
present. This failure is difficult for a user to diagnose.

Sox 14.3.1 was available in Debian Lenny, and specified libgomp1
version >= 4.2.1. So repeating that here.


2. IO:Socket::SSL

LMS does not include a bundled IO:Socket::SSL. Although LMS operates
without the presence of IO:Socket::SSL package, HTTPS streams, etc.
will not be available.

Source package is libio-socket-ssl-perl.


3. Others

libstdc++6
libgcc1

A number of the bundled binaries and CPAN packages depend on these two
libraries.

zlib1g

Image::Scale and Audio::Scan require the zlib library.