### PR TITLE
Debian: Add additional package dependency 'ca-certificates', remove 'libgomp1'

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Package: logitechmediaserver
 Architecture: all
 Conflicts: slimp3,slimserver,squeezecenter,squeezeboxserver
 Replaces: slimp3,slimserver,squeezecenter,squeezeboxserver
-Depends: perl (>= 5.8.8), adduser, libc6, libgcc1, libstdc++6, zlib1g, libio-socket-ssl-perl, libgomp1 (>= 4.2.1)
+Depends: perl (>= 5.8.8), adduser, libc6, libgcc1, libstdc++6, zlib1g, libio-socket-ssl-perl, ca-certificates, libgomp1 (>= 4.2.1)
 Description: Streaming Audio Server
  Logitech Media Server is a cross-platform streaming media server that supports a wide range
  of formats, including AAC, AIFF, FLAC, Ogg Vorbis, MP3, WAV, and WMA.

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Package: logitechmediaserver
 Architecture: all
 Conflicts: slimp3,slimserver,squeezecenter,squeezeboxserver
 Replaces: slimp3,slimserver,squeezecenter,squeezeboxserver
-Depends: perl (>= 5.8.8), adduser, libc6, libgcc1, libstdc++6, zlib1g, libio-socket-ssl-perl, ca-certificates, libgomp1 (>= 4.2.1)
+Depends: perl (>= 5.8.8), adduser, libc6, libgcc1, libstdc++6, zlib1g, libio-socket-ssl-perl, ca-certificates
 Description: Streaming Audio Server
  Logitech Media Server is a cross-platform streaming media server that supports a wide range
  of formats, including AAC, AIFF, FLAC, Ogg Vorbis, MP3, WAV, and WMA.


### PR DESCRIPTION
These proposed changes update the Debian package dependencies as follows:

- Add `ca-certificates`

A dependency on `libio-socket-ssl-perl` (`IO::Socket::SSL`) was added in February 2018 to ensure that the LMS installation is capable of using HTTPS.

However, this is not enough to provide seamless operation. At present, many HTTPS operations will simply fail in the absence of a valid set of root certificates. On a Debian system the `ca-certificates` package provides a collection apparently shipped with Mozilla's browser.

https://packages.debian.org/buster/ca-certificates

The issue came to light when I installed LMS in a minimal Debian installation that did not have the root certificates installed. It was impossible to enter login details for mysqueezebox.com during the first time setup web page, due to HTTPS failures. And there were many other HTTPS failures.

In a nutshell: if we want `IO::Socket::SSL`, then we will want some root certificates.

I've proposed that the package be recorded as a hard dependency because LMS simply won't function satisfactorily without root certificates, and I am not aware of an alternative Debian package.

Another approach would be to leave the installation of root certificates to the user. Both `wget` and `curl` packages take this approach, they _recommend_ the package, without recording a hard dependency. But then they can operate without it.

- Remove `libgomp1`

The LMS bundled Sox binary was updated in August 2018. Amongst other things, OpenMP support was removed from the build, and there is no longer a dependency on the OpenMP library (`libgomp1`).

So removing this dependency as it no longer exists.
