### PR TITLE
Debian: Add a systemd service file for LMS

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,14 +2,15 @@ Source: logitechmediaserver
 Section: sound
 Priority: optional
 Maintainer: Logitech/Slim Devices <debian@slimdevices.com>
-Build-Depends: debhelper (>= 9)
+Build-Depends: debhelper (>= 9), dh-systemd (>= 1.5)
 Standards-Version: 3.9.5
 
 Package: logitechmediaserver
 Architecture: all
 Conflicts: slimp3,slimserver,squeezecenter,squeezeboxserver
 Replaces: slimp3,slimserver,squeezecenter,squeezeboxserver
-Depends: perl (>= 5.8.8), adduser, libc6, libgcc1, libstdc++6, zlib1g, libio-socket-ssl-perl, ca-certificates
+Depends: ${misc:Depends}, perl (>= 5.8.8), adduser, libc6, libgcc1, libstdc++6, zlib1g, libio-socket-ssl-perl, ca-certificates
+Pre-Depends: ${misc:Pre-Depends}
 Description: Streaming Audio Server
  Logitech Media Server is a cross-platform streaming media server that supports a wide range
  of formats, including AAC, AIFF, FLAC, Ogg Vorbis, MP3, WAV, and WMA.

--- a/debian/logitechmediaserver.default
+++ b/debian/logitechmediaserver.default
@@ -1,4 +1,10 @@
-# User to run Logitech Media Server as
+# User to run Logitech Media Server as.
+# Only applicable to platforms that do not use systemd.
+# Running the server as a user other than the default squeezeboxserver
+# is not recommended.
 SLIMUSER=squeezeboxserver
 
+# Additional options for the server.
+# For example: SLIMOPTIONS="--failsafe --nomysqueezebox"
+# Use '/usr/sbin/squeezeboxserver --help' to obtain a full listing.
 SLIMOPTIONS=""

--- a/debian/logitechmediaserver.service
+++ b/debian/logitechmediaserver.service
@@ -1,0 +1,174 @@
+#=======================================================================
+# Unit section
+#=======================================================================
+
+[Unit]
+
+Description=Logitech Media Server
+
+# Ensures LMS is shutdown before network. And that the network service
+# has at least been started.
+
+After=network.target
+
+# Make LMS wait for network-online.target (if it gets started).
+# See notes below.
+
+After=network-online.target
+
+#-----------------------------------------------------------------------
+# Some notes on networking targets:
+#-----------------------------------------------------------------------
+
+# We leave it to the user to specify 'Wants=network-online.target' if he
+# chooses, because it may not suit all users. But we specify
+# 'After=network-online.target' because the SysV init script has
+# essentially behaved that way by virtue of the 'Required-Start: $all'
+# stanza included within it.
+# This is also the approach taken in Debian's & Ubuntu's implementation
+# of 'rc.local.service'.
+#
+# On systemd >= 217, user might execute:
+#   'systemctl add-wants logitechmediaserver.service network-online.target'
+#
+# The effects of the 'After' and 'Wants' 'network-online' stanzas are
+# very system dependent. They may or may not ensure that LMS starts up
+# after network connections have been established, and they may or may
+# not cause a delay in LMS start up.
+#
+# 'After=network-online.target' schedules LMS to start after the network
+# is fully up, whatever that may mean. But it is only effective if the
+# 'network-online.target' is active and, even then, it is only effective
+# if the user's system has been, or can be, configured to wait
+# appropriately for network connections to be established before
+# reaching this target.
+#
+# 'Wants=network-online.target' would activate (pull in) that target.
+#
+
+#=======================================================================
+# Service section
+#=======================================================================
+
+[Service]
+
+#-----------------------------------------------------------------------
+# Set run time variables, essentially replicating the SysV init script.
+#-----------------------------------------------------------------------
+
+# Use of '/etc/default/logitechmediaserver' to set run time variables
+# is supported, for consistency with the init script.
+# But setting 'SLIMUSER' is not supported. This unit file will always
+# start LMS as user 'squeezeboxserver'.
+# The user may override that, the methods available depend on the
+# installed version of systemd.
+
+# Note one consequence of this approach: LMS can now see environment
+# variables that correspond to the defined run time variables, should it
+# choose to look (it doesn't at present). This behaviour is an artefact
+# of the approach adopted by this unit file and may well change. It
+# should not be relied upon in any way.
+
+# Set PATH - same value as set by SysV init script.
+
+Environment="PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin"
+
+# Default run time settings. These are used as arguments to LMS when it
+# is launched.
+
+Environment="LOGDIR=/var/log/squeezeboxserver/"
+Environment="PREFSDIR=/var/lib/squeezeboxserver/prefs"
+Environment="CACHEDIR=/var/lib/squeezeboxserver/cache"
+Environment="CHARSET=utf8"
+
+# Supplementary run time settings may be defined in
+# '/etc/default/logitechmediaserver'. Entries made here would override
+# the defaults defined above.
+
+EnvironmentFile=-/etc/default/logitechmediaserver
+
+#
+# If you want to add additional options use
+#    /usr/sbin/squeezeboxserver --help
+# for the supported options and place them into the file:
+#    /etc/default/logitechmediaserver.
+# For example:
+#    SLIMOPTIONS="--failsafe --nomysqueezebox"
+#
+
+#-----------------------------------------------------------------------
+# Set up user and logging.
+#-----------------------------------------------------------------------
+
+# Remark: User can't be parameterized in a unit file. We could choose to
+# run LMS as root, and pass the USER option to it. But that adds
+# unnecessary risk.
+
+User=squeezeboxserver
+Group=nogroup
+
+# LMS will fail to start if a writeable log directory does not exist and
+# it cannot create it. This can easily happen where '/var/log' is
+# mounted on a temporary file system and requires root permissions to
+# create.
+# This stanza instructs systemd to create the standard directory
+# '/var/log/squeezeboxserver' if it does not exist, with appropriate
+# permissions and ownership.
+# The user may specify a different directory by setting the 'LOGDIR'
+# run time variable, but it is then his responsibility to ensure that
+# it exists and is writeable.
+# Note: Only effective in systemd >= 235. Earlier releases will see
+# harmless 'Unknown lvalue' messages logged.
+
+LogsDirectory=squeezeboxserver
+LogsDirectoryMode=0755
+
+#-----------------------------------------------------------------------
+# Execution start
+#-----------------------------------------------------------------------
+
+# We want LMS to handle SIGPIPE, as it can help terminate misbehaving
+# transcoder pipelines.
+
+IgnoreSIGPIPE=no
+
+# LMS is stable. So we don't want systemd to restart it if it fails.
+# That just obscures errors.
+
+Restart=no
+
+# We do not instruct LMS to daemonize with the '--daemon' option,
+# systemd prefers that we don't. We need 'Type=simple', or 'Type=exec'.
+
+# Type currently defaults to 'simple', but may usefully default to
+# 'exec' in future ('exec' available in systemd >= 240). So left unset.
+
+#Type=simple
+
+ExecStart=/usr/sbin/squeezeboxserver --prefsdir $PREFSDIR --logdir $LOGDIR --cachedir $CACHEDIR --charset $CHARSET $SLIMOPTIONS
+
+#-----------------------------------------------------------------------
+# Execution termination
+#-----------------------------------------------------------------------
+
+KillMode=control-group
+KillSignal=SIGTERM
+
+# Never send HUP, LMS uses this to reinitialize cache, etc.
+SendSIGHUP=no
+
+# Same timeout as SysV init script. We definitely want to send that
+# final SIGKILL.
+TimeoutStopSec=30
+SendSIGKILL=Yes
+
+#=======================================================================
+# Install section
+#=======================================================================
+
+[Install]
+# Directly equivalent to run levels 2,3,4.
+# Also run level 5, 'graphical.target', because that pulls in
+# 'multi-user.target'.
+
+WantedBy=multi-user.target

--- a/debian/rules
+++ b/debian/rules
@@ -14,6 +14,15 @@ source=$(CURDIR)/../server
 %:
 	dh $@ --with=systemd
 
+# Be nice to older systems (Debian version <= 7) by removing an 'init-system-helpers'
+# package dependency if it has been generated. These systems cannot satisfy the
+# dependency, and the LMS package cannot be easily installed if it is left in place.
+# (debhelper <= 11 may add the dependency.)
+# LMS will install successfully with or without this package.
+override_dh_gencontrol:
+	dh_gencontrol
+	sed -i '/^Depends/s/init-system-helpers[^,]*,\s*//' ${base}/DEBIAN/control
+
 # Overrides for variances within Logitech Media Server file locations
 override_dh_perl:
 	# using hard-coded dependency in control file

--- a/debian/rules
+++ b/debian/rules
@@ -12,7 +12,7 @@ source=$(CURDIR)/../server
 
 # main packaging script based on dh7 syntax
 %:
-	dh $@ 
+	dh $@ --with=systemd
 
 # Overrides for variances within Logitech Media Server file locations
 override_dh_perl:


### PR DESCRIPTION
### Summary

As discussed in the forum thread "systemd service file for LMS":
https://forums.slimdevices.com/showthread.php?113114-systemd-service-file-for-LMS

This proposed change adds a _systemd_ unit file to the Debian installation package, and will stand in place of the "auto-generated" unit file that _systemd_ currently creates. The "auto-generated" unit file simply calls the existing SysV init script.

Main features:

- _squeezeboxserver_safe_ goes, and LMS is started directly by _systemd_. No "supervisor", if it fails it stops.

- Supports setting start up options by using _/etc/default/logitechmediaserver_, similar to the existing SysV init script. But LMS user is hardcoded to 'squeezeboxserver'.

- Checks that _/var/log/squeezeboxserver_ exists and is writeable, and creates it if not.
(Good for systems with _/var/log_ mounted as temporary file system).
(But only on modern versions of systemd).

- Addresses issue whereby LMS may start "too early", before network connections are configured.
In systemd-speak, by including an _After=network-online.target_ stanza in the unit file.
It is left to the user to configure his system in a manner that gives appropriate meaning to the _network-online.target_.

I have removed a "Service reload" ('HUP' to LMS) action from the draft unit file that I posted in the forum thread. I am not sure that the function that it supplies is useful. It can be added at a later date if it is, indeed, useful.

I have left a complete set of comments in the unit file itself, which should help to explain why each option is set the way it is, so I won't repeat them here. I'd propose leaving them in there to assist knowledgeable users, but perhaps it is too wordy.

I have successfully built a Debian package on both Debian 9 and Debian 10, and I have installed the resulting package successfully on Debian 7 through 9. It should work equally well on any Debian derived system, with or without _systemd_, including Ubuntu and Devuan (a non-systemd port of Debian).

So I think it will prove itself in the real world of LMS users, but I shall not be surprised if the real world of LMS users does generate a surprise or two.

### Commits

There are three commits:

**Debian: Add systemd service unit**

Adds boiler plate changes to Debian rules, config file, and the unit file itself. These are as described in the Debian wiki: https://wiki.debian.org/Teams/pkg-systemd/Packaging

**Debian: Add systemd service unit - support older systems without 'init-system-helpers'**

The boiler plate rules may or may not generate a dependency on a relatively new package, _init-system-helpers_.
This will break older Debian systems if the dependency is not removed, and there still appear to be plenty of users whose systems fall into this category. Installation will proceed successfully without it, although a "deb-systemd-helper: not found" message will be logged. Such users need to upgrade to a more modern system to remove it.

**Debian: Add systemd service unit - add explanatory comments to LMS default file**

This is not essential, but, I think helpful. It just adds additional explanatory comments in the existing LMS default file _/etc/default/logitechmediaserver_.

However, we should be aware that anyone who has edited his LMS default file away from the previously installed version will get the usual Debian "Configuration file has been modified" interactive prompt during installation. And that may trigger requests for help in the forum. I would hope not, but it might.
