### PR TITLE
Added use of PERL5LIB in SYSV script and in systemd unit file.

### DIFF
--- a/redhat/squeezeboxserver.init
+++ b/redhat/squeezeboxserver.init
@@ -164,6 +164,13 @@ else
 	exit 1
 fi
 
+# Do not change this, it will most likely break the squeezeboxserver
+# installation. The directory /usr/lib/perl5/vendor_perl is where the RPM
+# package drops the Slim perl modules. Setting PERL5LIB to this location will
+# make sure that the squeezebox server executable looks here before it scans the
+# directories in the perl @INC array.
+export PERL5LIB="/usr/lib/perl5/vendor_perl"
+
 # See how we were called.
 case "$1" in
 	start)

--- a/redhat/squeezeboxserver.service
+++ b/redhat/squeezeboxserver.service
@@ -6,7 +6,7 @@ After=network.target
 
 # These values can be overridden by means of a drop in file in  the
 # directory /etc/systemd/system/squeezeboxserver.service.d
-# Read man page for systemd.unit.
+# Read man page for systemd.unit and systemd.service.
 #
 # Or they can be overriden in /etc/sysconfig/squeezeboxserver
 # The first option is recommended.
@@ -22,6 +22,13 @@ Environment="SQUEEZEBOX_ADDITIONAL_ARGS="
 # in /etc/systemd/system/logitechmediaserver.service.d/*.conf
 EnvironmentFile=-/etc/sysconfig/squeezeboxserver
 
+# Do not change this, it will most likely break the squeezeboxserver
+# installation. The directory /usr/lib/perl5/vendor_perl is where the RPM
+# package drops the Slim perl modules. Setting PERL5LIB to this location will
+# make sure that the squeezebox server executable looks here before it scans the
+# directories in the perl @INC array.
+Environment="PERL5LIB=/usr/lib/perl5/vendor_perl"
+
 #Type=simple
 User=squeezeboxserver
 Group=squeezeboxserver
@@ -32,7 +39,7 @@ ExecStart=/usr/libexec/squeezeboxserver --prefsdir $SQUEEZEBOX_CFG_DIR --logdir 
 # drop-in file in /etc/systemd/system/logitechmediaserver.service.d/ if you
 # want the change to survive the next upgrade of logitechmediaserver.
 # Note: This setting may conflict with SQUEEZEBOX_LOG_DIR set here above. That 
-# is why I think it is better to keep them commented.
+# is why I think it is better to keep them commented by default.
 #LogsDirectory=squeezeboxserver
 #LogsDirectoryMode=0755
 


### PR DESCRIPTION
By setting PERL5LIB in the SYSV init script and in the systemd unit file we will work around the different values of the perl @INC array in the different distributions. With PERL5LIB set to /usr/lib/perl5/vendor_perl, the squeezebox server executable will search for modules in that directory before it searches any of the directories in the @INC array.

As result it is no longer needed to create a symbolic link pointing to /usr/lib/perl5/vendor_perl from a directory present in @INC on any of the RPM based distributions.