### PR TITLE
Use current container image for Debian Bullseye

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,5 +1,5 @@
 #Base image
-FROM debian:bullseye-20201209-slim
+FROM debian:bullseye-slim
 
 # Set environment variables
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Debian Bullseye is currently in Hard Freeze pending release, so should be a sufficiently reliable base for LMS 8.2 while it is in development.