### PR TITLE
Ignore logs on stdout in systemd service

### DIFF
--- a/debian/logitechmediaserver.service
+++ b/debian/logitechmediaserver.service
@@ -122,6 +122,12 @@ User=squeezeboxserver
 LogsDirectory=squeezeboxserver
 LogsDirectoryMode=0755
 
+# Since we launch LMS in the foreground (ie not daemonized) logs are
+# mirrored on stdout. Systemd normally processes logs on stdout, but
+# since LMS has its own logging framework we tell systemd to ignore
+# the stdout logs and skip log processing.
+StandardOutput=null
+
 #-----------------------------------------------------------------------
 # Execution start
 #-----------------------------------------------------------------------


### PR DESCRIPTION
The systemd service launches LMS in the foreground and this causes logs to be mirrored to stdout. See
https://github.com/Logitech/slimserver/blob/public/8.4/Slim/Utils/Log.pm#L166

Logs on stdout are picked up by systemd and processed, but since LMS has its own log processing we don't need systemd to handle log messages.

On a standard debian system the stdout logs would be sent to syslog and then written to file (syslog and daemon.log). This means that LMS logs would end up in three places (LMS logs, syslog and daemon.log). This is especially bad when doing debugging and all debug messages are written to three files - it gets very noisy.