### PR TITLE
Pass argument '--quiet' to LMS by default

### DIFF
--- a/debian/logitechmediaserver.default
+++ b/debian/logitechmediaserver.default
@@ -7,4 +7,7 @@ SLIMUSER=squeezeboxserver
 # Additional options for the server.
 # For example: SLIMOPTIONS="--d_startup --failsafe --nomysqueezebox"
 # Use '/usr/sbin/squeezeboxserver --help' to obtain a full listing.
-SLIMOPTIONS=""
+#
+# LMS writes logs to file so '--quiet' is used to suppress logging
+# to stdout.
+SLIMOPTIONS="--quiet"


### PR DESCRIPTION
Systemd processes log messages on LMS stdout, but since LMS has its own logging system we don't need systemd to handle logs.

This helps avoid duplicated logs in case LMS is started through systemd.

This is an alternative to #41.