### PR TITLE
Pass additional launch arguments using EXTRA_ARGS environment variable

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -91,3 +91,6 @@ You can put a script called `custom-init.sh` in the configuration folder. If tha
 apt-get update -qq
 apt-get install --no-install-recommends -qy ffmpeg
 ```
+
+### Passing additional launch arguments
+An optional `EXTRA_ARGS` environment variable exists for passing additional arguments to Logitech Media Server process. For example, disabling the web interface could be achieved with `EXTRA_ARGS="--noweb"`.

--- a/Docker/start-container.sh
+++ b/Docker/start-container.sh
@@ -17,4 +17,7 @@ if [[ -f /config/custom-init.sh ]]; then
 fi
 
 echo Starting Logitech Media Server on port $HTTP_PORT...
-su squeezeboxserver -c '/usr/bin/perl /lms/slimserver.pl --prefsdir /config/prefs --logdir /config/logs --cachedir /config/cache --httpport $HTTP_PORT'
+if [[ -n "$EXTRA_ARGS" ]]; then
+	echo "Using additional arguments: $EXTRA_ARGS"
+fi
+su squeezeboxserver -c '/usr/bin/perl /lms/slimserver.pl --prefsdir /config/prefs --logdir /config/logs --cachedir /config/cache --httpport $HTTP_PORT $EXTRA_ARGS'


### PR DESCRIPTION
The Dockerfile doesn't currently support any way of passing additional arguments to the LMS process which results in either having to get creative by editing the image content live, creating a new local image using the official image as base just for a minor change or overriding /usr/bin/start-container with a locally modified copy as volume.

When using `host` mode networking, I had the need to specify `--httpaddr`, `--playeraddr`, `--streamaddr` and `--cliaddr` to avoid those from using the default 0.0.0.0 binding. I initially created BIND_ADDR but upon noticing issue #40, I concluded that EXTRA_ARGS would indeed be a more flexible solution for everyone. When EXTRA_ARGS is defined then its content will also be made visible with an additional `echo` after "Starting Logitech Media Server on port..." before starting the server process. Default behaviour stays the same when EXTRA_ARGS isn't used.