### PR TITLE
Log early startup messages to syslog

### DIFF
--- a/debian/squeezeboxserver_safe
+++ b/debian/squeezeboxserver_safe
@@ -38,7 +38,7 @@ do
   # builtin to return immediately with an exit status greater than
   # 128, immediately after which the trap is executed.
 
-  "$@" > /dev/null 2>&1 &
+  "$@" 1> >(logger) 2>&1 &
   SLIMPID=$!
   
   # wait for the server to get started before wait()


### PR DESCRIPTION
This change is designed to replicate the logging behaviour under systemd systems for non-systemd systems (i.e. those using the init.d script). This will ensure that early error messages, before LMS logging is up and running, are available in syslog. Once LMS is up, the default --quiet parameter will ensure that normal logging will not be duplicated in syslog.