### PR TITLE
RPM package requires awk

### DIFF
--- a/redhat/lyrionmusicserver.spec
+++ b/redhat/lyrionmusicserver.spec
@@ -92,7 +92,7 @@ Source6:        README.rebranding
 BuildRoot:	%{_tmppath}/%{name}-%{version}-buildroot
 Vendor:		Lyrion Community
 
-
+Requires:	/usr/bin/awk
 Requires:	perl >= 5.10.0
 Recommends:     perl(IO::Socket::SSL)
 


### PR DESCRIPTION
I tried installing the RPM in a SLES container, and found that `awk` was missing:

```console
desktop:~> podman run -it registry.suse.com/suse/sle15:15.6
Trying to pull registry.suse.com/suse/sle15:15.6...
Getting image source signatures
Copying blob 0b109ba7bbe2 done   |
Copying config 43536441fd done   |
Writing manifest to image destination
42935f653ebf:/ # zypper install https://downloads.lms-community.org/LogitechMediaServer_v8.5.2/logitechmediaserver-8.5.2-1.noarch.rpm
Refreshing service 'container-suseconnect-zypp'.
Retrieving repository 'SLE_BCI' metadata .................................[done]
Building repository 'SLE_BCI' cache ......................................[done]
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following 3 NEW packages are going to be installed:
  libgdbm4 logitechmediaserver perl

The following package has no support information from its vendor:
  logitechmediaserver

The following 2 packages are not supported by their vendor:
  libgdbm4 perl

3 new packages to install.
Overall download size: 93.3 MiB. Already cached: 0 B. After the operation,
additional 249.0 MiB will be used.

Backend:  classic_rpmtrans
Continue? [y/n/v/...? shows all options] (y):
Retrieving: libgdbm4-1.12-1.418.x86_64 (SLE_BCI)            (1/3),  76.5 KiB
Retrieving: libgdbm4-1.12-1.418.x86_64.rpm ...............................[done]
Retrieving: perl-5.26.1-150300.17.17.1.x86_64 (SLE_BCI)     (2/3),   6.5 MiB
Retrieving: perl-5.26.1-150300.17.17.1.x86_64.rpm ............[done (6.3 MiB/s)]
Retrieving: logitechmediaserver-8.5.2-1.noarch (Plain RPM files cache)
                                                            (3/3),  86.7 MiB
logitechmediaserver-8.5.2-1.noarch.rpm:
    Package header is not signed!

logitechmediaserver-8.5.2-1.noarch (Plain RPM files cache): Signature verification failed [6-File is unsigned]
Abort, retry, ignore? [a/r/i] (a): i

Checking for file conflicts: .............................................[done]
(1/3) Installing: libgdbm4-1.12-1.418.x86_64 .............................[done]
(2/3) Installing: perl-5.26.1-150300.17.17.1.x86_64 ......................[done]
/var/tmp/rpm-tmp.a41KKK: line 106: awk: command not found
Point your web browser to http://42935f653ebf:9000/ to configure Logitech Media Server.
(3/3) Installing: logitechmediaserver-8.5.2-1.noarch .....................[done]
42935f653ebf:/ # exit
```

It probably makes sense to replace use of `awk` with `perl`, but ensuring `awk` is installed is a quick fix for now.