### PR TITLE
Docker: change permissions of user running the server

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -4,7 +4,6 @@ FROM debian:bookworm-slim
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LC_ALL="C.UTF-8" LANG="en_US.UTF-8" LANGUAGE="en_US.UTF-8"
-ENV PUID=99 PGID=100
 ENV HTTP_PORT=9000
 
 # Install packages
@@ -15,11 +14,7 @@ RUN apt-get update -qq  && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Add & configure user
-RUN useradd squeezeboxserver && \
-	usermod -u $PUID squeezeboxserver && \
-	usermod -g $PGID squeezeboxserver && \
-	usermod -d /home squeezeboxserver && \
-	usermod -a -G audio squeezeboxserver
+RUN useradd -M -d /nonexistent -s /usr/sbin/nologin -G audio squeezeboxserver
 
 # Add startup script
 COPY start-container.sh /usr/bin/start-container

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -30,7 +30,7 @@ RUN mkdir -p /config /music /playlist /lms
 
 COPY . /lms
 COPY Slim-Utils-OS-Custom.pm /lms/Slim/Utils/OS/Custom.pm
-RUN chown -R squeezeboxserver:nogroup /config /playlist && chmod -R a+rX /lms
+RUN chown -R squeezeboxserver:squeezeboxserver /config /playlist && chmod -R a+rX /lms
 
 VOLUME /config /music /playlist
 

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -4,6 +4,7 @@ FROM debian:bookworm-slim
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LC_ALL="C.UTF-8" LANG="en_US.UTF-8" LANGUAGE="en_US.UTF-8"
+ENV PUID=99 PGID=100
 ENV HTTP_PORT=9000
 
 # Install packages
@@ -14,7 +15,11 @@ RUN apt-get update -qq  && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Add & configure user
-RUN useradd -M -d /nonexistent -s /usr/sbin/nologin -G audio squeezeboxserver
+RUN useradd squeezeboxserver && \
+	usermod -u $PUID squeezeboxserver && \
+	groupmod -o -g "$PGID" squeezeboxserver && \
+	usermod -d /home squeezeboxserver && \
+	usermod -a -G audio squeezeboxserver
 
 # Add startup script
 COPY start-container.sh /usr/bin/start-container

--- a/Docker/start-container.sh
+++ b/Docker/start-container.sh
@@ -20,4 +20,4 @@ echo Starting Lyrion Music Server on port $HTTP_PORT...
 if [[ -n "$EXTRA_ARGS" ]]; then
 	echo "Using additional arguments: $EXTRA_ARGS"
 fi
-su squeezeboxserver -s /bin/sh -c '/usr/bin/perl /lms/slimserver.pl --prefsdir /config/prefs --logdir /config/logs --cachedir /config/cache --httpport $HTTP_PORT $EXTRA_ARGS'
+su squeezeboxserver -c '/usr/bin/perl /lms/slimserver.pl --prefsdir /config/prefs --logdir /config/logs --cachedir /config/cache --httpport $HTTP_PORT $EXTRA_ARGS'

--- a/Docker/start-container.sh
+++ b/Docker/start-container.sh
@@ -6,10 +6,10 @@ PUID=${PUID:-`id -u squeezeboxserver`}
 PGID=${PGID:-`id -g squeezeboxserver`}
 
 usermod -o -u "$PUID" squeezeboxserver
-groupmod -o -g "$PGID" nogroup
+groupmod -o -g "$PGID" squeezeboxserver
 
 #Add permissions
-chown -R squeezeboxserver:nogroup /config /playlist
+chown -R squeezeboxserver:squeezeboxserver /config /playlist
 
 if [[ -f /config/custom-init.sh ]]; then
 	echo "Running custom initialization script..."
@@ -20,4 +20,4 @@ echo Starting Lyrion Music Server on port $HTTP_PORT...
 if [[ -n "$EXTRA_ARGS" ]]; then
 	echo "Using additional arguments: $EXTRA_ARGS"
 fi
-su squeezeboxserver -c '/usr/bin/perl /lms/slimserver.pl --prefsdir /config/prefs --logdir /config/logs --cachedir /config/cache --httpport $HTTP_PORT $EXTRA_ARGS'
+su squeezeboxserver -s /bin/sh -c '/usr/bin/perl /lms/slimserver.pl --prefsdir /config/prefs --logdir /config/logs --cachedir /config/cache --httpport $HTTP_PORT $EXTRA_ARGS'


### PR DESCRIPTION
See discussion #84 :
 - Use group 'squeezeboxserver' instead of 'nogroup' for file permissions
 - The environment variable `-e PGID=NNNN` now works correctly.