### PR TITLE
Create squeezeboxserver as systemuser with uid 499

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:bookworm-slim
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LC_ALL="C.UTF-8" LANG="en_US.UTF-8" LANGUAGE="en_US.UTF-8"
-ENV PUID=99 PGID=100
+ENV PUID=499 PGID=100
 ENV HTTP_PORT=9000
 
 # Install packages
@@ -15,9 +15,8 @@ RUN apt-get update -qq  && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Add & configure user
-RUN useradd squeezeboxserver && \
-	usermod -u $PUID squeezeboxserver && \
-	groupmod -o -g "$PGID" squeezeboxserver && \
+RUN adduser --system --group -uid=$PUID squeezeboxserver && \
+	usermod -g $PGID squeezeboxserver && \
 	usermod -d /home squeezeboxserver && \
 	usermod -a -G audio squeezeboxserver
 

--- a/Docker/start-container.sh
+++ b/Docker/start-container.sh
@@ -5,8 +5,15 @@ umask 0002
 PUID=${PUID:-`id -u squeezeboxserver`}
 PGID=${PGID:-`id -g squeezeboxserver`}
 
+# Set uid of user squeezeboxserver to $PUID
+echo Set uid of user squeezeboxserver to $PUID
 usermod -o -u "$PUID" squeezeboxserver
+
+# Set id of group squeezeboxserver to $PGID and set gid of user squeezeboxserver to $PGID
+echo Set id of group squeezeboxserver to $PGID
 groupmod -o -g "$PGID" squeezeboxserver
+echo Set gid of user squeezeboxserver to $PGID
+usermod -g $PGID squeezeboxserver
 
 #Add permissions
 chown -R squeezeboxserver:squeezeboxserver /config /playlist
@@ -20,4 +27,4 @@ echo Starting Lyrion Music Server on port $HTTP_PORT...
 if [[ -n "$EXTRA_ARGS" ]]; then
 	echo "Using additional arguments: $EXTRA_ARGS"
 fi
-su squeezeboxserver -c '/usr/bin/perl /lms/slimserver.pl --prefsdir /config/prefs --logdir /config/logs --cachedir /config/cache --httpport $HTTP_PORT $EXTRA_ARGS'
+su squeezeboxserver -s /bin/sh -c '/usr/bin/perl /lms/slimserver.pl --prefsdir /config/prefs --logdir /config/logs --cachedir /config/cache --httpport $HTTP_PORT $EXTRA_ARGS'


### PR DESCRIPTION
This request makes two changes to the docker image:
 - Make 499 the default user id. 
 - Create squeezeboxserver as systemuser, i.e. without loginshell.

After the discussion in the forum some weeks ago I have tested this on my  own server (a Synology NAS) for three mounth..
Along with some other changes (see https://github.com/osnieh/slimserver-platforms/tree/Check_Variables/Docker) I have encountered no problems with this.

