### PR TITLE
Syncronize the exclude lists between buildme.pl and Docker/.dockerignore

### DIFF
--- a/Docker/.dockerignore
+++ b/Docker/.dockerignore
@@ -1,8 +1,7 @@
-CPAN/arch/5.8
 CPAN/arch/5.1*
 CPAN/arch/5.2*
 CPAN/arch/5.3[0248]
-CPAN/Font
+CPAN/arch/5.40
 Bin/arm-linux
 Bin/darwin* 
 Bin/i86* 
@@ -12,5 +11,6 @@ Bin/powerpc-linux
 Bin/sparc-linux
 icudt46b.dat
 icudt58b.dat
+Slim/Plugin/PreventStandby
 Plugins/*
 .git

--- a/buildme.pl
+++ b/buildme.pl
@@ -44,7 +44,8 @@ my $dirsToExcludeForMacOS = "5.10 5.12 5.14 5.16 5.20 5.22 5.24 5.26 5.28 5.30 5
 my $dirsToExcludeForWin64 = "5.10 5.12 5.14 5.16 5.18 5.20 5.22 5.24 5.26 5.28 5.30 5.34 5.36 5.38 5.40 i386-freebsd-64int i386-linux x86_64-linux x86_64-linux-gnu-thread-multi i86pc-solaris-thread-multi-64int darwin darwin-x86_64 sparc-linux arm-linux armhf-linux powerpc-linux aarch64-linux OS/Debian.pm OS/Linux.pm OS/OSX.pm OS/pCP.pm OS/RedHat.pm OS/Suse.pm OS/SlimService.pm OS/Synology.pm OS/SqueezeOS.pm OS/Unix.pm icudt46b.dat icudt46l.dat icudt58b.dat icudt58l.dat";
 
 # for Docker we provide x86_64 and armhf for Perl 5.36 only
-my $dirsToExcludeForDocker = "$dirsToExcludeForLinuxPackage 5.20 5.22 5.24 5.26 5.28 5.30 5.32 5.34 5.38 5.40 i386-linux i86pc-solaris-thread-multi-64int sparc-linux powerpc-linux icudt46b.dat icudt58b.dat";
+# Dont't forget to keep this list in sync with the file "Docker/.dockerignore"
+my $dirsToExcludeForDocker = "$dirsToExcludeForLinuxPackage 5.20 5.22 5.24 5.26 5.28 5.30 5.32 5.34 5.38 5.40 i386-linux arm-linux icudt46b.dat icudt58b.dat";
 
 # Musical Fidelity comes with Perl 5.22
 my $dirsToExcludeForEncore = "$dirsToExcludeForLinuxPackage 5.20 5.24 5.26 5.28 5.30 5.32 5.34 5.36 5.38 5.40 i386-linux arm-linux armhf-linux aarch64-linux i86pc-solaris-thread-multi-64int sparc-linux powerpc-linux icudt46l.dat icudt46b.dat";


### PR DESCRIPTION
The list `$dirsToExcludeForDocker` in the buildscript `buildme.pl` and the entries in the file `Docker/.dockerignore` and both excluding files from the dockerimage.
This PR is syncronizing these two lists, because they got different. 

For the future we could think about doing the file exclusion only in one place.