### PR TITLE
Remove arm-linux from excludes in buildme.pl and put basic excludes from buildme.pl to Docker/.dockerignore

### DIFF
--- a/Docker/.dockerignore
+++ b/Docker/.dockerignore
@@ -1,3 +1,7 @@
+#
+# Directories to exclude when building the docker image:
+# For Docker we provide x86_64 and armhf for Perl 5.36 only
+#
 CPAN/arch/5.1*
 CPAN/arch/5.2*
 CPAN/arch/5.3[0248]
@@ -12,5 +16,14 @@ Bin/sparc-linux
 icudt46b.dat
 icudt58b.dat
 Slim/Plugin/PreventStandby
-Plugins/*
+#
+# Some basic excludes
+#
+.editorconfig
 .git
+.github
+.gitignore
+**/t
+**/ext-all-debug.js
+Firmware/*.bin
+Plugins/*

--- a/buildme.pl
+++ b/buildme.pl
@@ -45,7 +45,7 @@ my $dirsToExcludeForWin64 = "5.10 5.12 5.14 5.16 5.18 5.20 5.22 5.24 5.26 5.28 5
 
 # for Docker we provide x86_64 and armhf for Perl 5.36 only
 # Dont't forget to keep this list in sync with the file "Docker/.dockerignore"
-my $dirsToExcludeForDocker = "$dirsToExcludeForLinuxPackage 5.20 5.22 5.24 5.26 5.28 5.30 5.32 5.34 5.38 5.40 i386-linux arm-linux icudt46b.dat icudt58b.dat";
+my $dirsToExcludeForDocker = "$dirsToExcludeForLinuxPackage 5.20 5.22 5.24 5.26 5.28 5.30 5.32 5.34 5.38 5.40 i386-linux icudt46b.dat icudt58b.dat";
 
 # Musical Fidelity comes with Perl 5.22
 my $dirsToExcludeForEncore = "$dirsToExcludeForLinuxPackage 5.20 5.24 5.26 5.28 5.30 5.32 5.34 5.36 5.38 5.40 i386-linux arm-linux armhf-linux aarch64-linux i86pc-solaris-thread-multi-64int sparc-linux powerpc-linux icudt46l.dat icudt46b.dat";


### PR DESCRIPTION
1. Remove `arm-linux` from excludes in `buildme.pl`: I have added it yesterday, but it also removes the dir `CPAN/arch/5.36/arm-linux-gnueabihf-thread-multi-64int`
2. Add the relevant basic excludes from `buildme.pl` (line 19) to `Docker/.dockerignore`