### PR TITLE
Debian: Add `procps` and `psmisc` packages - some plugins want them

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Package: lyrionmusicserver
 Architecture: all
 Conflicts: slimp3,slimserver,squeezecenter,squeezeboxserver,logitechmediaserver
 Replaces: slimp3,slimserver,squeezecenter,squeezeboxserver,logitechmediaserver
-Depends: ${misc:Depends}, perl (>= 5.14.0), adduser, libc6, libgcc1, libstdc++6, zlib1g, libio-socket-ssl-perl, ca-certificates, libcrypt-openssl-rsa-perl
+Depends: ${misc:Depends}, perl (>= 5.14.0), adduser, libc6, libgcc1, libstdc++6, zlib1g, libio-socket-ssl-perl, ca-certificates, libcrypt-openssl-rsa-perl, procps, psmisc
 Pre-Depends: ${misc:Pre-Depends}
 Description: Streaming Audio Server
  Lyrion Music Server is a cross-platform streaming media server that supports a wide range


### PR DESCRIPTION
This proposed change is a follow up to LMS issue [Container log error "ps not found, #1441"](https://github.com/LMS-Community/slimserver/issues/1441).

The Docker build has already been updated in commits 784016915f693f032e9775b34f8598e347c13580 and 9766f4cb6e2b9dc560a65b0c75d8b92f48c9e223, and now includes packages `procps` and `psmisc` to resolve the issue.

This change adds these package dependencies to the Debian build as well. This ensures that the packages will be present even on a "bare-bones" Debian installation.
