### PR TITLE
Add package opus-tools to docker image

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -10,7 +10,7 @@ ENV HTTP_PORT=9000
 # Install packages
 RUN apt-get update -qq  && \
 	apt-get install --no-install-recommends -qy procps psmisc wget curl perl tzdata libcrypt-blowfish-perl libwww-perl libfont-freetype-perl liblinux-inotify2-perl \
-	libdata-dump-perl libio-socket-ssl-perl libnet-ssleay-perl libcrypt-ssleay-perl libcrypt-openssl-rsa-perl libssl-dev libgomp1 libasound2 lame && \
+	libdata-dump-perl libio-socket-ssl-perl libnet-ssleay-perl libcrypt-ssleay-perl libcrypt-openssl-rsa-perl libssl-dev libgomp1 libasound2 lame opus-tools && \
 	apt-get clean -qy && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
https://github.com/mtxmiller/LyrPlay needs opus-tools for Opus transcoding. This enables efficient streaming to mobile devices.

Right now there is a manual way to install opus-tools after downloading the image, but this is not very user-friendly: https://github.com/mtxmiller/LyrPlay?tab=readme-ov-file#enabling-mobile-transcode-oggopusflac