### PR TITLE
Modernize RPM macro comments and conditional building

### DIFF
--- a/buildme.pl
+++ b/buildme.pl
@@ -651,7 +651,7 @@ sub buildRPM {
 
         # Do it
         my $date = strftime('%Y-%m-%d', localtime());
-        print `rpmbuild -bb --with $releaseType --define="src_basename $defaultDestName" --define="_version $version" --define="_src_date $date" --define="_revision $revision" --define='_topdir $buildDir/rpm' $buildDir/rpm/SPECS/lyrionmusicserver.spec`;
+        print `rpmbuild -bb --with $releaseType --define="src_basename $defaultDestName" --define="_version $version" --define="_revision $revision" --define='_topdir $buildDir/rpm' $buildDir/rpm/SPECS/lyrionmusicserver.spec`;
 
 	## Just move the file out of the building directory, and put it into the destDir
 	print "INFO: Moving $buildDir/rpm/RPMS/noarch/*.rpm to $destDir\n";

--- a/redhat/lyrionmusicserver.spec
+++ b/redhat/lyrionmusicserver.spec
@@ -1,15 +1,16 @@
-# The following macros can either be defined here or passed into rpmbuild as macros
+# The following macros can either be defined here or passed into
+# rpmbuild with the --define or --with options.
+#
 # This is required:
-# %%define _version 7.7
+# %%define _version 9.2.0
+#
 # One (and only one) of the following is required:
 # %%define _with_trunk 1
 # %%define _with_branch 1
 # %%define _with_release 1
-# These are required with _with_trunk or _with_branch
-# %%define _src_date 2007-12-07
-# %%define _rpm_date 20071207
-# The following is required with _with_branch
-# %%define _branch 7.7
+#
+# The following is required with _with_trunk or _with_branch:
+# %%define _revision 1781670901
 
 # As from version 9.0.0 the logitech media server has been re-branded 
 # to Lyrion Music Server. It was decided to also properly re-name all

--- a/redhat/lyrionmusicserver.spec
+++ b/redhat/lyrionmusicserver.spec
@@ -1,16 +1,17 @@
 # The following macros can either be defined here or passed into
-# rpmbuild with the --define or --with options.
+# rpmbuild with the --define option.
 #
 # This is required:
 # %%define _version 9.2.0
 #
-# One (and only one) of the following is required:
-# %%define _with_trunk 1
-# %%define _with_branch 1
-# %%define _with_release 1
-#
-# The following is required with _with_trunk or _with_branch:
+# The following is required with trunk or branch:
 # %%define _revision 1781670901
+#
+# One of the following may be specified with rpmbuild's --with option.
+# The default is release.
+%bcond trunk 0
+%bcond branch 0
+%bcond release %{without trunk} && %{without branch}
 
 # As from version 9.0.0 the logitech media server has been re-branded 
 # to Lyrion Music Server. It was decided to also properly re-name all
@@ -45,19 +46,12 @@
 # don't terminate build due to binaries
 %global _binaries_in_noarch_packages_terminate_build 0
 
-%define build_trunk %{?_with_trunk:1}0
-%define build_branch %{?_with_branch:1}0
-%define build_release %{?_with_release:1}0
-
-
-%if %{build_trunk}
+%if %{with trunk} || %{with branch}
 %define rpm_release 0.%{increment}.%{_revision}
-%endif
-%if %{build_branch}
-%define rpm_release 0.%{increment}.%{_revision}
-%endif
-%if %{build_release}
+%elif %{with release}
 %define rpm_release 1
+%else
+%{error:One of the conditonals trunk, branch or release is required}
 %endif
 
 # The variable src_basename  is passed to the build by the buildme.pl script.


### PR DESCRIPTION
- Drop mention of obsolete RPM macros `%_branch`, `%_rpm_date` and `%_src_date`.  It looks like we haven’t made use of these for many years.
- Mention the `%_revision` macro.
- Drop our custom `%build_trunk`, `%build_branch` and `%build_release` macros, in favour of the standard `%{with …}` macro.
- Provide explicit defaults for `%_with_trunk`, `%_with_branch` and `%_with_release`, using the `%bcond` macro.

The [`%bcond` macro requires `rpmbuild` 4.17.1](https://rpm-software-management.github.io/rpm/manual/conditionalbuilds.html#using-bcond-new-in-rpm-4171) (released 2022).