### PR TITLE
RPM: Recommend Font::FreeType

### DIFF
--- a/redhat/lyrionmusicserver.spec
+++ b/redhat/lyrionmusicserver.spec
@@ -134,6 +134,10 @@ Requires:      perl(subs)
 Requires:      perl(Compress::Raw::Zlib)
 Requires:      perl(Digest::SHA)
 
+# Required for Unicode support on the fluorescent screens on old
+# hardware players:
+Recommends:    perl(Font::FreeType)
+
 # For Red Hat based distributions, Recommend perl so that the Perl core is
 # pulled in for use by LMS plugins. We use Recommends instead of Requires so
 # that users can remove unneeded packages if they want too.


### PR DESCRIPTION
Pull in RPM `perl-Font-FreeType` from the OS, when available, to enable Unicode support on the fluorescent screens on old hardware players.

See e.g., https://forums.lyrion.org/forum/user-forums/logitech-media-server/108343-can-someone-confirm-the-lms-that-came-with-picoreplayer-can-display-unicode-chars?p=1409312#post1409312 for background on why this module effectively isn’t bundled.