### PR TITLE
Specify RPM tag Source0 as a downloadable URL

### DIFF
--- a/buildme.pl
+++ b/buildme.pl
@@ -627,14 +627,14 @@ sub buildRPM {
 	}
 
 	## Now we need to build a tarball ...
-	print "INFO: Building $buildDir/$defaultDestName.tgz for the RPM...\n";
+	print "INFO: Building $buildDir/$destName.tgz for the RPM...\n";
 
-	buildTarball($dirsToExcludeForRPM, "$buildDir/$defaultDestName");
+	buildTarball($dirsToExcludeForRPM, "$buildDir/$destName");
 
 	## We already built a tarball, so now lets use it...
-	print "INFO: Moving $buildDir/$defaultDestName.tgz to $buildDir/rpm/SOURCES...\n";
-	system("mv $buildDir/$defaultDestName.tgz $buildDir/rpm/SOURCES");
 
+	print "INFO: Moving $buildDir/$destName.tgz to $buildDir/rpm/SOURCES/...\n";
+	system("mv $buildDir/$destName.tgz $buildDir/rpm/SOURCES/");
 	## Copy the various SPEC< Config, etc files into the right dirs...
         copy("$buildDir/platforms/redhat/lyrionmusicserver.config", "$buildDir/rpm/SOURCES");
         copy("$buildDir/platforms/redhat/lyrionmusicserver.logrotate", "$buildDir/rpm/SOURCES");

--- a/redhat/lyrionmusicserver.spec
+++ b/redhat/lyrionmusicserver.spec
@@ -76,7 +76,11 @@ Summary:        Lyrion Music Server
 
 License:	GPL and proprietary
 URL:		https://www.lyrion.org
-Source0:	%{src_basename}.tgz
+%if %{with release}
+Source0:	https://downloads.lms-community.org/LyrionMusicServer_v%{version}/%{src_basename}-%{version}.tgz
+%else
+Source0:	https://downloads.lms-community.org/nightly/%{src_basename}-%{version}-%{_revision}.tgz
+%endif
 Source1:	%{shortname}.config
 Source3:	%{shortname}.logrotate
 Source4:	%{shortname}.service
@@ -165,7 +169,11 @@ player. It supports MP3, AAC, WMA, FLAC, Ogg Vorbis, WAV and more!
 As of version 7.7 it also supports UPnP clients.
 
 %prep
-%setup -q -n %{src_basename}
+%if %{with release}
+%autosetup -n %{src_basename}-%{version}
+%else
+%autosetup -n %{src_basename}-%{version}-%{_revision}
+%endif
 
 
 %build


### PR DESCRIPTION
This makes it easier to build the RPM using a more conventional RPM building workflow, if one prefers to do that instead of relying on `buildme.pl`.