### PR TITLE
RPM documentation tidy up

### DIFF
--- a/redhat/lyrionmusicserver.spec
+++ b/redhat/lyrionmusicserver.spec
@@ -175,12 +175,10 @@ As of version 7.7 it also supports UPnP clients.
 %autosetup -n %{src_basename}-%{version}-%{_revision}
 %endif
 
+cp %SOURCE5 %SOURCE6 ./
+
 
 %build
-# Rearrange some documentation
-mv lib/README README.lib
-mv HTML/README.txt README.HTML
-
 # Remove mysqld and other unneeded files
 rm -rf Bin/darwin
 rm -rf Bin/i386-freebsd-64int
@@ -235,8 +233,6 @@ ln -rs $RPM_BUILD_ROOT%{_var}/lib/%{shortname}/Plugins \
 install -Dp -m644 %SOURCE1 $RPM_BUILD_ROOT%{_sysconfdir}/sysconfig/%{shortname}
 install -Dp -m644 %SOURCE3 $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/%{shortname}
 install -Dp -m644 %SOURCE4 $RPM_BUILD_ROOT%{_unitdir}/%{shortname}.service
-install -Dp -m644 %SOURCE5 $RPM_BUILD_ROOT%{_datadir}/%{shortname}/README.systemd
-install -Dp -m644 %SOURCE6 $RPM_BUILD_ROOT%{_datadir}/%{shortname}/README.rebranding
 install -Dp -m644 %SOURCE7 $RPM_BUILD_ROOT%{_presetdir}/50-%{shortname}.preset
 touch $RPM_BUILD_ROOT%{_var}/lib/%{shortname}/prefs/server.prefs
 touch $RPM_BUILD_ROOT%{_var}/lib/%{shortname}/prefs/log.conf
@@ -490,8 +486,15 @@ exit 0
 %defattr(-,root,root,-)
 
 # Documentation files
-%doc Changelog*.html README.lib README.HTML
 %license License.txt
+%doc Changelog*.html
+%doc README.md
+%doc %{_datadir}/%{shortname}/HTML/Default/html/ext/README.TXT
+%doc %{_datadir}/%{shortname}/HTML/README.txt
+%doc %{_datadir}/%{shortname}/lib/README
+%doc %{_usr}/lib/perl5/vendor_perl/Slim/Plugin/TT/README
+%doc %{basename %SOURCE5}
+%doc %{basename %SOURCE6}
 
 # Main files
 %{_usr}/lib/perl5/vendor_perl/Slim

--- a/redhat/lyrionmusicserver.spec
+++ b/redhat/lyrionmusicserver.spec
@@ -490,7 +490,8 @@ exit 0
 %defattr(-,root,root,-)
 
 # Documentation files
-%doc Changelog*.html License.* README.lib README.HTML
+%doc Changelog*.html README.lib README.HTML
+%license License.txt
 
 # Main files
 %{_usr}/lib/perl5/vendor_perl/Slim


### PR DESCRIPTION
- Include `README.md`.
- Place `README.rebranding` and `README.systemd` in the documentation directory.
- Leave `README.html` and `README.lib` in their natural directories, whilst still marking them as documentation.
- Mark `Slim/Plugin/TT/README` and `HTML/Default/html/ext/README.TXT` as documentation.
- Mark `License.txt` as being a licence file.

This triggers a few `File listed twice` warnings from `rpmbuild`, but I think we can live with that for now.  The cure would be to more carefully list the contents of `/usr/share/lyrionmusicserver`, rather than adding the whole directory, but that’s a bigger change.