### PR TITLE
RPM: Drop hard-coded Vendor tag

### DIFF
--- a/redhat/lyrionmusicserver.spec
+++ b/redhat/lyrionmusicserver.spec
@@ -88,7 +88,6 @@ Source5:	README.systemd
 Source6:        README.rebranding
 Source7:        %{shortname}.preset
 BuildRoot:	%{_tmppath}/%{name}-%{version}-buildroot
-Vendor:		Lyrion Community
 
 BuildRequires:   systemd-rpm-macros
 Requires(pre):   /usr/bin/getent

--- a/redhat/lyrionmusicserver.spec
+++ b/redhat/lyrionmusicserver.spec
@@ -69,7 +69,7 @@
 %global shortname lyrionmusicserver
 
 Name:		%{src_basename}
-Packager:	Lyrion Community - please visit www.lyrion.org
+Packager:	Lyrion Community
 Version:	%{_version}
 Release:	%{rpm_release}
 Summary:        Lyrion Music Server


### PR DESCRIPTION
This should be set in the build environment (see accompanying commit to `slimserver` repository) rather than in the `.spec` file, so that if someone builds the RPM on their local machine, say, it doesn’t look like an official build.

While we’re here, drop the redundant URL from Packager tag.  The URL is in the URL tag, so we don’t need it in the Packager tag too.